### PR TITLE
Add API networking layer and error handling

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -31,7 +31,6 @@ linter:
     - avoid_returning_null
     - prefer_inlined_adds
     - avoid_empty_else
-    - sort_constructors_first
     - prefer_collection_literals
     - avoid_escaping_inner_quotes
 

--- a/lib/core/networking/api_constants.dart
+++ b/lib/core/networking/api_constants.dart
@@ -1,0 +1,22 @@
+abstract class ApiConstants {
+  static const String baseUrl = 'https://vcare.integration25.com/api';
+  static const String login = 'auth/login';
+}
+
+abstract class ApiErrors {
+  static const String badRequestError = 'badRequestError';
+  static const String noContent = 'noContent';
+  static const String forbiddenError = 'forbiddenError';
+  static const String unauthorizedError = 'unauthorizedError';
+  static const String notFoundError = 'notFoundError';
+  static const String conflictError = 'conflictError';
+  static const String internalServerError = 'internalServerError';
+  static const String unknownError = 'unknownError';
+  static const String timeoutError = 'timeoutError';
+  static const String defaultError = 'defaultError';
+  static const String cacheError = 'cacheError';
+  static const String noInternetError = 'noInternetError';
+  static const String loadingMessage = 'loading_message';
+  static const String retryAgainMessage = 'retry_again_message';
+  static const String ok = 'Ok';
+}

--- a/lib/core/networking/api_error_handler.dart
+++ b/lib/core/networking/api_error_handler.dart
@@ -1,0 +1,174 @@
+import 'package:dio/dio.dart';
+
+import 'api_constants.dart';
+import 'api_error_model.dart';
+
+// TODO: wallahy I will refactor this .. Omar Ahmed
+enum DataSource {
+  NO_CONTENT,
+  BAD_REQUEST,
+  FORBIDDEN,
+  UNAUTORISED,
+  NOT_FOUND,
+  INTERNAL_SERVER_ERROR,
+  CONNECT_TIMEOUT,
+  CANCEL,
+  RECIEVE_TIMEOUT,
+  SEND_TIMEOUT,
+  CACHE_ERROR,
+  NO_INTERNET_CONNECTION,
+  // API_LOGIC_ERROR,
+  DEFAULT
+}
+
+class ResponseCode {
+  static const int SUCCESS = 200; // success with data
+  static const int NO_CONTENT = 201; // success with no data (no content)
+  static const int BAD_REQUEST = 400; // failure, API rejected request
+  static const int UNAUTORISED = 401; // failure, user is not authorised
+  static const int FORBIDDEN = 403; //  failure, API rejected request
+  static const int INTERNAL_SERVER_ERROR = 500; // failure, crash in server side
+  static const int NOT_FOUND = 404; // failure, not found
+  static const int API_LOGIC_ERROR = 422; // API , lOGIC ERROR
+
+  // local status code
+  static const int CONNECT_TIMEOUT = -1;
+  static const int CANCEL = -2;
+  static const int RECIEVE_TIMEOUT = -3;
+  static const int SEND_TIMEOUT = -4;
+  static const int CACHE_ERROR = -5;
+  static const int NO_INTERNET_CONNECTION = -6;
+  static const int DEFAULT = -7;
+}
+
+class ResponseMessage {
+  static const String NO_CONTENT =
+      ApiErrors.noContent; // success with no data (no content)
+  static const String BAD_REQUEST =
+      ApiErrors.badRequestError; // failure, API rejected request
+  static const String UNAUTORISED =
+      ApiErrors.unauthorizedError; // failure, user is not authorised
+  static const String FORBIDDEN =
+      ApiErrors.forbiddenError; //  failure, API rejected request
+  static const String INTERNAL_SERVER_ERROR =
+      ApiErrors.internalServerError; // failure, crash in server side
+  static const String NOT_FOUND =
+      ApiErrors.notFoundError; // failure, crash in server side
+
+  // local status code
+  static String CONNECT_TIMEOUT = ApiErrors.timeoutError;
+  static String CANCEL = ApiErrors.defaultError;
+  static String RECIEVE_TIMEOUT = ApiErrors.timeoutError;
+  static String SEND_TIMEOUT = ApiErrors.timeoutError;
+  static String CACHE_ERROR = ApiErrors.cacheError;
+  static String NO_INTERNET_CONNECTION = ApiErrors.noInternetError;
+  static String DEFAULT = ApiErrors.defaultError;
+}
+
+extension DataSourceExtension on DataSource {
+  ApiErrorModel getFailure() {
+    switch (this) {
+      case DataSource.NO_CONTENT:
+        return ApiErrorModel(
+            code: ResponseCode.NO_CONTENT, message: ResponseMessage.NO_CONTENT);
+      case DataSource.BAD_REQUEST:
+        return ApiErrorModel(
+            code: ResponseCode.BAD_REQUEST,
+            message: ResponseMessage.BAD_REQUEST);
+      case DataSource.FORBIDDEN:
+        return ApiErrorModel(
+            code: ResponseCode.FORBIDDEN, message: ResponseMessage.FORBIDDEN);
+      case DataSource.UNAUTORISED:
+        return ApiErrorModel(
+            code: ResponseCode.UNAUTORISED,
+            message: ResponseMessage.UNAUTORISED);
+      case DataSource.NOT_FOUND:
+        return ApiErrorModel(
+            code: ResponseCode.NOT_FOUND, message: ResponseMessage.NOT_FOUND);
+      case DataSource.INTERNAL_SERVER_ERROR:
+        return ApiErrorModel(
+            code: ResponseCode.INTERNAL_SERVER_ERROR,
+            message: ResponseMessage.INTERNAL_SERVER_ERROR);
+      case DataSource.CONNECT_TIMEOUT:
+        return ApiErrorModel(
+            code: ResponseCode.CONNECT_TIMEOUT,
+            message: ResponseMessage.CONNECT_TIMEOUT);
+      case DataSource.CANCEL:
+        return ApiErrorModel(
+            code: ResponseCode.CANCEL, message: ResponseMessage.CANCEL);
+      case DataSource.RECIEVE_TIMEOUT:
+        return ApiErrorModel(
+            code: ResponseCode.RECIEVE_TIMEOUT,
+            message: ResponseMessage.RECIEVE_TIMEOUT);
+      case DataSource.SEND_TIMEOUT:
+        return ApiErrorModel(
+            code: ResponseCode.SEND_TIMEOUT,
+            message: ResponseMessage.SEND_TIMEOUT);
+      case DataSource.CACHE_ERROR:
+        return ApiErrorModel(
+            code: ResponseCode.CACHE_ERROR,
+            message: ResponseMessage.CACHE_ERROR);
+      case DataSource.NO_INTERNET_CONNECTION:
+        return ApiErrorModel(
+            code: ResponseCode.NO_INTERNET_CONNECTION,
+            message: ResponseMessage.NO_INTERNET_CONNECTION);
+      case DataSource.DEFAULT:
+        return ApiErrorModel(
+            code: ResponseCode.DEFAULT, message: ResponseMessage.DEFAULT);
+    }
+  }
+}
+
+class ErrorHandler implements Exception {
+  late ApiErrorModel apiErrorModel;
+
+  ErrorHandler.handle(error) {
+    if (error is DioException) {
+      // dio error so its an error from response of the API or from dio itself
+      apiErrorModel = _handleError(error);
+    } else {
+      // default error
+      apiErrorModel = DataSource.DEFAULT.getFailure();
+    }
+  }
+}
+
+ApiErrorModel _handleError(DioException error) {
+  switch (error.type) {
+    case DioExceptionType.connectionTimeout:
+      return DataSource.CONNECT_TIMEOUT.getFailure();
+    case DioExceptionType.sendTimeout:
+      return DataSource.SEND_TIMEOUT.getFailure();
+    case DioExceptionType.receiveTimeout:
+      return DataSource.RECIEVE_TIMEOUT.getFailure();
+    case DioExceptionType.badResponse:
+      if (error.response != null &&
+          error.response?.statusCode != null &&
+          error.response?.statusMessage != null) {
+        return ApiErrorModel.fromJson(error.response!.data);
+      } else {
+        return DataSource.DEFAULT.getFailure();
+      }
+    case DioExceptionType.unknown:
+      if (error.response != null &&
+          error.response?.statusCode != null &&
+          error.response?.statusMessage != null) {
+        return ApiErrorModel.fromJson(error.response!.data);
+      } else {
+        return DataSource.DEFAULT.getFailure();
+      }
+    case DioExceptionType.cancel:
+      return DataSource.CANCEL.getFailure();
+    case DioExceptionType.connectionError:
+      return DataSource.DEFAULT.getFailure();
+    case DioExceptionType.badCertificate:
+      return DataSource.DEFAULT.getFailure();
+    case DioExceptionType.badResponse:
+      return DataSource.DEFAULT.getFailure();
+  }
+}
+
+class ApiInternalStatus {
+  static const int SUCCESS = 0;
+  static const int FAILURE = 1;
+}

--- a/lib/core/networking/api_error_model.dart
+++ b/lib/core/networking/api_error_model.dart
@@ -1,0 +1,21 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'api_error_model.g.dart';
+
+@JsonSerializable()
+class ApiErrorModel {
+  int? code;
+  String? message;
+
+  ApiErrorModel({this.code, required this.message});
+
+  factory ApiErrorModel.fromJson(Map<String, dynamic> json) =>
+      _$ApiErrorModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ApiErrorModelToJson(this);
+
+  @override
+  String toString() {
+    return 'ApiErrorModel{code: $code, message: $message}';
+  }
+}

--- a/lib/core/networking/api_error_model.g.dart
+++ b/lib/core/networking/api_error_model.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'api_error_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ApiErrorModel _$ApiErrorModelFromJson(Map<String, dynamic> json) =>
+    ApiErrorModel(
+      code: (json['code'] as num?)?.toInt(),
+      message: json['message'] as String?,
+    );
+
+Map<String, dynamic> _$ApiErrorModelToJson(ApiErrorModel instance) =>
+    <String, dynamic>{
+      'code': instance.code,
+      'message': instance.message,
+    };

--- a/lib/core/networking/api_result.dart
+++ b/lib/core/networking/api_result.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_advanced/core/networking/api_error_model.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'api_result.freezed.dart';
+
+@Freezed()
+abstract class ApiResult<T> with _$ApiResult<T> {
+  const factory ApiResult.success(T data) = Success<T>;
+  const factory ApiResult.failure(ApiErrorModel error) = Failure<T>;
+}

--- a/lib/core/networking/api_result.freezed.dart
+++ b/lib/core/networking/api_result.freezed.dart
@@ -1,0 +1,359 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'api_result.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$ApiResult<T> {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(T data) success,
+    required TResult Function(ApiErrorModel error) failure,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(T data)? success,
+    TResult? Function(ApiErrorModel error)? failure,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(T data)? success,
+    TResult Function(ApiErrorModel error)? failure,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Success<T> value) success,
+    required TResult Function(Failure<T> value) failure,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(Success<T> value)? success,
+    TResult? Function(Failure<T> value)? failure,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Success<T> value)? success,
+    TResult Function(Failure<T> value)? failure,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ApiResultCopyWith<T, $Res> {
+  factory $ApiResultCopyWith(
+          ApiResult<T> value, $Res Function(ApiResult<T>) then) =
+      _$ApiResultCopyWithImpl<T, $Res, ApiResult<T>>;
+}
+
+/// @nodoc
+class _$ApiResultCopyWithImpl<T, $Res, $Val extends ApiResult<T>>
+    implements $ApiResultCopyWith<T, $Res> {
+  _$ApiResultCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ApiResult
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+abstract class _$$SuccessImplCopyWith<T, $Res> {
+  factory _$$SuccessImplCopyWith(
+          _$SuccessImpl<T> value, $Res Function(_$SuccessImpl<T>) then) =
+      __$$SuccessImplCopyWithImpl<T, $Res>;
+  @useResult
+  $Res call({T data});
+}
+
+/// @nodoc
+class __$$SuccessImplCopyWithImpl<T, $Res>
+    extends _$ApiResultCopyWithImpl<T, $Res, _$SuccessImpl<T>>
+    implements _$$SuccessImplCopyWith<T, $Res> {
+  __$$SuccessImplCopyWithImpl(
+      _$SuccessImpl<T> _value, $Res Function(_$SuccessImpl<T>) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ApiResult
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? data = freezed,
+  }) {
+    return _then(_$SuccessImpl<T>(
+      freezed == data
+          ? _value.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as T,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SuccessImpl<T> implements Success<T> {
+  const _$SuccessImpl(this.data);
+
+  @override
+  final T data;
+
+  @override
+  String toString() {
+    return 'ApiResult<$T>.success(data: $data)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SuccessImpl<T> &&
+            const DeepCollectionEquality().equals(other.data, data));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(data));
+
+  /// Create a copy of ApiResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SuccessImplCopyWith<T, _$SuccessImpl<T>> get copyWith =>
+      __$$SuccessImplCopyWithImpl<T, _$SuccessImpl<T>>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(T data) success,
+    required TResult Function(ApiErrorModel error) failure,
+  }) {
+    return success(data);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(T data)? success,
+    TResult? Function(ApiErrorModel error)? failure,
+  }) {
+    return success?.call(data);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(T data)? success,
+    TResult Function(ApiErrorModel error)? failure,
+    required TResult orElse(),
+  }) {
+    if (success != null) {
+      return success(data);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Success<T> value) success,
+    required TResult Function(Failure<T> value) failure,
+  }) {
+    return success(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(Success<T> value)? success,
+    TResult? Function(Failure<T> value)? failure,
+  }) {
+    return success?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Success<T> value)? success,
+    TResult Function(Failure<T> value)? failure,
+    required TResult orElse(),
+  }) {
+    if (success != null) {
+      return success(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Success<T> implements ApiResult<T> {
+  const factory Success(final T data) = _$SuccessImpl<T>;
+
+  T get data;
+
+  /// Create a copy of ApiResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$SuccessImplCopyWith<T, _$SuccessImpl<T>> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$FailureImplCopyWith<T, $Res> {
+  factory _$$FailureImplCopyWith(
+          _$FailureImpl<T> value, $Res Function(_$FailureImpl<T>) then) =
+      __$$FailureImplCopyWithImpl<T, $Res>;
+  @useResult
+  $Res call({ApiErrorModel error});
+}
+
+/// @nodoc
+class __$$FailureImplCopyWithImpl<T, $Res>
+    extends _$ApiResultCopyWithImpl<T, $Res, _$FailureImpl<T>>
+    implements _$$FailureImplCopyWith<T, $Res> {
+  __$$FailureImplCopyWithImpl(
+      _$FailureImpl<T> _value, $Res Function(_$FailureImpl<T>) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ApiResult
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? error = null,
+  }) {
+    return _then(_$FailureImpl<T>(
+      null == error
+          ? _value.error
+          : error // ignore: cast_nullable_to_non_nullable
+              as ApiErrorModel,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$FailureImpl<T> implements Failure<T> {
+  const _$FailureImpl(this.error);
+
+  @override
+  final ApiErrorModel error;
+
+  @override
+  String toString() {
+    return 'ApiResult<$T>.failure(error: $error)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$FailureImpl<T> &&
+            (identical(other.error, error) || other.error == error));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, error);
+
+  /// Create a copy of ApiResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$FailureImplCopyWith<T, _$FailureImpl<T>> get copyWith =>
+      __$$FailureImplCopyWithImpl<T, _$FailureImpl<T>>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(T data) success,
+    required TResult Function(ApiErrorModel error) failure,
+  }) {
+    return failure(error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(T data)? success,
+    TResult? Function(ApiErrorModel error)? failure,
+  }) {
+    return failure?.call(error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(T data)? success,
+    TResult Function(ApiErrorModel error)? failure,
+    required TResult orElse(),
+  }) {
+    if (failure != null) {
+      return failure(error);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Success<T> value) success,
+    required TResult Function(Failure<T> value) failure,
+  }) {
+    return failure(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(Success<T> value)? success,
+    TResult? Function(Failure<T> value)? failure,
+  }) {
+    return failure?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Success<T> value)? success,
+    TResult Function(Failure<T> value)? failure,
+    required TResult orElse(),
+  }) {
+    if (failure != null) {
+      return failure(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Failure<T> implements ApiResult<T> {
+  const factory Failure(final ApiErrorModel error) = _$FailureImpl<T>;
+
+  ApiErrorModel get error;
+
+  /// Create a copy of ApiResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$FailureImplCopyWith<T, _$FailureImpl<T>> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/core/networking/api_service.dart
+++ b/lib/core/networking/api_service.dart
@@ -1,0 +1,17 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_advanced/core/networking/api_constants.dart';
+import 'package:flutter_advanced/features/auth/data/models/login_request_body.dart';
+import 'package:flutter_advanced/features/auth/data/models/login_response.dart';
+import 'package:retrofit/http.dart';
+
+part 'api_service.g.dart';
+
+@RestApi(baseUrl: ApiConstants.baseUrl)
+abstract class ApiService {
+  factory ApiService(Dio dio, {String? baseUrl}) = _ApiService;
+
+  @POST(ApiConstants.login)
+  Future<LoginResponse> login(
+    @Body() LoginRequestBody body,
+  );
+}

--- a/lib/core/networking/api_service.g.dart
+++ b/lib/core/networking/api_service.g.dart
@@ -1,0 +1,76 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'api_service.dart';
+
+// **************************************************************************
+// RetrofitGenerator
+// **************************************************************************
+
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations
+
+class _ApiService implements ApiService {
+  _ApiService(this._dio, {this.baseUrl, this.errorLogger}) {
+    baseUrl ??= 'https://vcare.integration25.com/api';
+  }
+
+  final Dio _dio;
+
+  String? baseUrl;
+
+  final ParseErrorLogger? errorLogger;
+
+  @override
+  Future<LoginResponse> login(LoginRequestBody body) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(body.toJson());
+    final _options = _setStreamType<LoginResponse>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            'auth/login',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late LoginResponse _value;
+    try {
+      _value = LoginResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
+    if (T != dynamic &&
+        !(requestOptions.responseType == ResponseType.bytes ||
+            requestOptions.responseType == ResponseType.stream)) {
+      if (T == String) {
+        requestOptions.responseType = ResponseType.plain;
+      } else {
+        requestOptions.responseType = ResponseType.json;
+      }
+    }
+    return requestOptions;
+  }
+
+  String _combineBaseUrls(String dioBaseUrl, String? baseUrl) {
+    if (baseUrl == null || baseUrl.trim().isEmpty) {
+      return dioBaseUrl;
+    }
+
+    final url = Uri.parse(baseUrl);
+
+    if (url.isAbsolute) {
+      return url.toString();
+    }
+
+    return Uri.parse(dioBaseUrl).resolveUri(url).toString();
+  }
+}

--- a/lib/core/networking/dio_factory.dart
+++ b/lib/core/networking/dio_factory.dart
@@ -1,0 +1,52 @@
+import 'package:dio/dio.dart';
+// import 'package:flutter_complete_project/core/helpers/constants.dart';
+import 'package:pretty_dio_logger/pretty_dio_logger.dart';
+
+// import '../helpers/shared_pref_helper.dart';
+
+abstract class DioFactory {
+  /// private constructor as I don't want to allow creating an instance of this class
+  DioFactory._();
+
+  static Dio? dio;
+
+  static Dio getDio() {
+    Duration timeOut = const Duration(seconds: 30);
+
+    if (dio == null) {
+      dio = Dio();
+      dio!
+        ..options.connectTimeout = timeOut
+        ..options.receiveTimeout = timeOut;
+      //  addDioHeaders();
+      addDioInterceptor();
+      return dio!;
+    } else {
+      return dio!;
+    }
+  }
+
+  // static void addDioHeaders() async {
+  //   dio?.options.headers = {
+  //     'Accept': 'application/json',
+  //     'Authorization':
+  //         'Bearer ${await SharedPrefHelper.getSecuredString(SharedPrefKeys.userToken)}',
+  //   };
+  // }
+
+  // static void setTokenIntoHeaderAfterLogin(String token) {
+  //   dio?.options.headers = {
+  //     'Authorization': 'Bearer $token',
+  //   };
+  // }
+
+  static void addDioInterceptor() {
+    dio?.interceptors.add(
+      PrettyDioLogger(
+        requestBody: true,
+        requestHeader: true,
+        responseHeader: true,
+      ),
+    );
+  }
+}

--- a/lib/docdoc_app.dart
+++ b/lib/docdoc_app.dart
@@ -15,7 +15,7 @@ class DocdocApp extends StatelessWidget {
       designSize: const Size(375, 812),
       minTextAdapt: true,
       splitScreenMode: true,
-      child: MaterialApp(
+      builder: (_, __) => MaterialApp(
         debugShowCheckedModeBanner: false,
         onGenerateRoute: onGenerateRoute,
         initialRoute: RoutesStrings.onBoarding,

--- a/lib/features/auth/data/models/login_request_body.dart
+++ b/lib/features/auth/data/models/login_request_body.dart
@@ -1,0 +1,15 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'login_request_body.g.dart';
+
+@JsonSerializable()
+class LoginRequestBody {
+  final String email;
+  final String password;
+
+  LoginRequestBody({
+    required this.email,
+    required this.password,
+  });
+  Map<String, dynamic> toJson() => _$LoginRequestBodyToJson(this);
+}

--- a/lib/features/auth/data/models/login_request_body.g.dart
+++ b/lib/features/auth/data/models/login_request_body.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'login_request_body.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+LoginRequestBody _$LoginRequestBodyFromJson(Map<String, dynamic> json) =>
+    LoginRequestBody(
+      email: json['email'] as String,
+      password: json['password'] as String,
+    );
+
+Map<String, dynamic> _$LoginRequestBodyToJson(LoginRequestBody instance) =>
+    <String, dynamic>{
+      'email': instance.email,
+      'password': instance.password,
+    };

--- a/lib/features/auth/data/models/login_response.dart
+++ b/lib/features/auth/data/models/login_response.dart
@@ -1,0 +1,28 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'login_response.g.dart';
+
+@JsonSerializable()
+class LoginResponse {
+  String? message;
+  int? code;
+  bool? status;
+  @JsonKey(name: 'data')
+  UserData? data;
+
+  LoginResponse({this.message, this.code, this.status, this.data});
+  factory LoginResponse.fromJson(Map<String, dynamic> json) =>
+      _$LoginResponseFromJson(json);
+}
+
+@JsonSerializable()
+class UserData {
+  String? token;
+  @JsonKey(name: 'username')
+  String? userName;
+
+  UserData({this.token, this.userName});
+
+  factory UserData.fromJson(Map<String, dynamic> json) =>
+      _$UserDataFromJson(json);
+}

--- a/lib/features/auth/data/models/login_response.g.dart
+++ b/lib/features/auth/data/models/login_response.g.dart
@@ -1,0 +1,35 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'login_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+LoginResponse _$LoginResponseFromJson(Map<String, dynamic> json) =>
+    LoginResponse(
+      message: json['message'] as String?,
+      code: (json['code'] as num?)?.toInt(),
+      status: json['status'] as bool?,
+      data: json['data'] == null
+          ? null
+          : UserData.fromJson(json['data'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$LoginResponseToJson(LoginResponse instance) =>
+    <String, dynamic>{
+      'message': instance.message,
+      'code': instance.code,
+      'status': instance.status,
+      'data': instance.data,
+    };
+
+UserData _$UserDataFromJson(Map<String, dynamic> json) => UserData(
+      token: json['token'] as String?,
+      userName: json['username'] as String?,
+    );
+
+Map<String, dynamic> _$UserDataToJson(UserData instance) => <String, dynamic>{
+      'token': instance.token,
+      'username': instance.userName,
+    };

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -86,6 +86,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  build_daemon:
+    dependency: transitive
+    description:
+      name: build_daemon
+      sha256: "294a2edaf4814a378725bfe6358210196f5ea37af89ecd81bfa32960113d4948"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.3"
+  build_resolvers:
+    dependency: transitive
+    description:
+      name: build_resolvers
+      sha256: "99d3980049739a985cf9b21f30881f46db3ebc62c5b8d5e60e27440876b1ba1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  build_runner:
+    dependency: "direct dev"
+    description:
+      name: build_runner
+      sha256: "74691599a5bc750dc96a6b4bfd48f7d9d66453eab04c7f4063134800d6a5c573"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.14"
+  build_runner_core:
+    dependency: transitive
+    description:
+      name: build_runner_core
+      sha256: "22e3aa1c80e0ada3722fe5b63fd43d9c8990759d0a2cf489c8c5d7b2bdebc021"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.0"
   built_collection:
     dependency: transitive
     description:
@@ -322,6 +354,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.4"
+  frontend_server_client:
+    dependency: transitive
+    description:
+      name: frontend_server_client
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   gap:
     dependency: "direct main"
     description:
@@ -346,6 +386,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  graphs:
+    dependency: transitive
+    description:
+      name: graphs
+      sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
   html:
     dependency: transitive
     description:
@@ -362,6 +410,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  http_multi_server:
+    dependency: transitive
+    description:
+      name: http_multi_server
+      sha256: aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
   http_parser:
     dependency: transitive
     description:
@@ -386,6 +442,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.19.0"
+  io:
+    dependency: transitive
+    description:
+      name: io
+      sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.1"
   json_annotation:
     dependency: "direct main"
     description:
@@ -474,6 +546,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   nested:
     dependency: transitive
     description:
@@ -554,6 +634,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  pool:
+    dependency: transitive
+    description:
+      name: pool
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.1"
   posix:
     dependency: transitive
     description:
@@ -611,7 +699,7 @@ packages:
     source: hosted
     version: "4.4.2"
   retrofit_generator:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: retrofit_generator
       sha256: da17daf8cfdf695a402c894e4eebf91d2e815a47368820dd7a0b41a027739a9c
@@ -674,6 +762,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
+  shelf:
+    dependency: transitive
+    description:
+      name: shelf
+      sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.2"
+  shelf_web_socket:
+    dependency: transitive
+    description:
+      name: shelf_web_socket
+      sha256: cc36c297b52866d203dbf9332263c94becc2fe0ceaa9681d07b6ef9807023b67
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -719,6 +823,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  stream_transform:
+    dependency: transitive
+    description:
+      name: stream_transform
+      sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
@@ -743,6 +855,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.3"
+  timing:
+    dependency: transitive
+    description:
+      name: timing
+      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   typed_data:
     dependency: transitive
     description:
@@ -815,6 +935,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "3c12d96c0c9a4eec095246debcea7b86c0324f22df69893d538fcc6f1b8cce83"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.6"
+  web_socket_channel:
+    dependency: transitive
+    description:
+      name: web_socket_channel
+      sha256: "0b8e2457400d8a859b7b2030786835a28a8e80836ef64402abef392ff4f1d0e5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,18 +43,17 @@ dependencies:
   intl: null
   json_annotation: ^4.9.0
   json_serializable: ^6.9.3
+  retrofit_generator: ^9.1.7
   pretty_dio_logger: ^1.4.0
   retrofit: ^4.4.2
 
 dev_dependencies:
+  build_runner: ^2.4.14
   flutter_lints: ^5.0.0
   flutter_native_splash: ^2.4.4
-
-  # lottie : null
   flutter_test:
     sdk: flutter
-  retrofit_generator: ^9.1.7
-
+ 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 # The following section is specific to Flutter packages.
@@ -105,7 +104,6 @@ flutter_native_splash:
   # branding_bottom_padding: 24
   # color_dark: "#121212"
   # image_dark: assets/logo-production.png
-
   android_12:
     image: assets/images/splash12.png
     icon_background_color: "#ffffff"


### PR DESCRIPTION
- Removed `sort_constructors_first` lint rule from `analysis_options.yaml`.
- Introduced `ApiConstants` and `ApiErrors` for managing API URLs and error messages.
- Implemented `ApiErrorHandler` to handle various API error scenarios using Dio.
- Created `ApiErrorModel` for error representation and serialization.
- Added `ApiResult` to handle success and failure responses using Freezed.
- Developed `ApiService` with Retrofit for API requests, including a login endpoint.
- Set up `DioFactory` for configuring Dio instances with interceptors.
- Added models for login request and response, including JSON serialization.
- Updated `pubspec.yaml` and `pubspec.lock` to include necessary dependencies for networking and code generation.